### PR TITLE
 Fix race condition for experiment trial selection

### DIFF
--- a/src/metaopt/core/io/database/__init__.py
+++ b/src/metaopt/core/io/database/__init__.py
@@ -119,6 +119,30 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         pass
 
     @abstractmethod
+    def read_and_write(self, collection_name, query, data, selection=None):
+        """Read a collection's document and update the found document.
+
+        If many documents are found, the first one is selected.
+
+        Returns the updated document, or None if nothing found.
+
+        Parameters
+        ----------
+        collection_name : str
+           A collection inside database, a table.
+        query : dict
+           Filter entries in collection.
+        data : dict or list of dicts
+           New data that will **update** the entry.
+        selection : dict, optional
+           Elements of matched entries to return, the projection.
+
+        :return: updated first matched document or None if nothing found
+
+        """
+        pass
+
+    @abstractmethod
     def count(self, collection_name, query=None):
         """Count the number of documents in a collection which match the `query`.
 

--- a/src/metaopt/core/io/database/mongodb.py
+++ b/src/metaopt/core/io/database/mongodb.py
@@ -119,6 +119,25 @@ class MongoDB(AbstractDB):
 
         return dbdocs
 
+    def read_and_write(self, collection_name, query, data, selection=None):
+        """Read a collection's document and update the found document.
+
+        Returns the updated document, or None if nothing found.
+
+        .. seealso:: :meth:`AbstractDB.read_and_write` for
+                     argument documentation.
+
+        """
+        dbcollection = self._db[collection_name]
+
+        update_data = {'$set': data}
+
+        dbdoc = dbcollection.find_one_and_update(
+            query, update_data, projection=selection,
+            return_document=pymongo.ReturnDocument.AFTER)
+
+        return dbdoc
+
     def count(self, collection_name, query=None):
         """Count the number of documents in a collection which match the `query`.
 


### PR DESCRIPTION
Related to #10, #14 and #42
Needs #36 to be merged.

1. Add `read_and_write()` to `Database`
2. Use `read_and_write()` instead of `write()` to reserve trials inside `Experiment.reserve_trial()`

Why:

Some operations require atomicity. For instance, when selecting a new trial, between the first read to database, the potential scoring and the random selection, another process could reserve it concurrently. To avoid such concurrency problems, we must ensure at the update time that the status was not altered during the selection.

How:

Using `read_and_write()` can ensure atomic operations. At update time, the process only proceed to update if the selected document remained unaltered. In our specific case, we could look at the status, since by design  only "reserved" trials can possibly change. If there was a race condition the "looser" process simply rollbacks and retry its operation. This solution is in line with 'mongodb''s spirit regarding concurrency.

Note:

My decision to add `read_and_write()` instead of adding an `atomic` argument to `write()` was to avoid increasing the complexity of `write()` for a simple use case. `write()` supports operations on many documents, MongoDB atomic operations do not. Furthermore, it seems our requirements for atomic operation are fairly rare, occurring only at registration time for experiments and reservation time for trials. In both cases, those operations only affects one document.