### PR TITLE
Decrease unittest time for database

### DIFF
--- a/src/metaopt/core/io/database/mongodb.py
+++ b/src/metaopt/core/io/database/mongodb.py
@@ -9,8 +9,6 @@
 
 """
 import pymongo
-from pymongo import MongoClient
-from pymongo.uri_parser import parse_uri
 
 from metaopt.core.io.database import (AbstractDB, DatabaseError)
 
@@ -43,11 +41,11 @@ class MongoDB(AbstractDB):
         self._sanitize_attrs()
 
         try:
-            self._conn = MongoClient(host=self.host,
-                                     port=self.port,
-                                     username=self.username,
-                                     password=self.password,
-                                     authSource=self.name)
+            self._conn = pymongo.MongoClient(host=self.host,
+                                             port=self.port,
+                                             username=self.username,
+                                             password=self.password,
+                                             authSource=self.name)
             self._db = self._conn[self.name]
             self._db.command('ismaster')  # .. seealso:: :meth:`is_connected`
         except pymongo.errors.ConnectionFailure as e:
@@ -145,10 +143,10 @@ class MongoDB(AbstractDB):
         """Sanitize attributes using MongoDB's 'uri_parser' module."""
         try:
             # Host can be a valid MongoDB URI
-            settings = parse_uri(self.host)
+            settings = pymongo.uri_parser.parse_uri(self.host)
         except pymongo.errors.InvalidURI:  # host argument was a hostname
             if self.port is None:
-                self.port = MongoClient.PORT
+                self.port = pymongo.MongoClient.PORT
         else:  # host argument was a URI
             # Arguments in MongoClient overwrite elements from URI
             self.host, _port = settings['nodelist'][0]

--- a/tests/unittests/core/mongodb_test.py
+++ b/tests/unittests/core/mongodb_test.py
@@ -25,9 +25,11 @@ def patch_mongo_client(monkeypatch):
     def mock_class(*args, **kwargs):
         # 1 sec, defaults to 20 secs otherwise
         kwargs['serverSelectionTimeoutMS'] = 1.
+        # NOTE: Can't use pymongo.MongoClient otherwise there is an infinit
+        # recursion; mock(mock(mock(mock(...(MongoClient)...))))
         return MongoClient(*args, **kwargs)
 
-    monkeypatch.setattr('metaopt.core.io.database.mongodb.MongoClient', mock_class)
+    monkeypatch.setattr('pymongo.MongoClient', mock_class)
 
 
 @pytest.mark.usefixtures("null_db_instances")


### PR DESCRIPTION
Why:

Unittest for bad connections takes several seconds, more than the sum of
all other unit tests. This is only due to a default large Timeout inside
pymongo when server does not respond.

How:

Mock pymongo's MongoClient to force serverSelectionTimeoutMS to 1.