### PR TITLE
Add indexation to databases and fix race condition for experiment configuration

### DIFF
--- a/src/metaopt/core/io/database/__init__.py
+++ b/src/metaopt/core/io/database/__init__.py
@@ -126,6 +126,11 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
            In the case of an update operation, if `query` fails to find a
            document that matches, insert of `data` will be performed instead.
 
+        :raises :exc:`DuplicateKeyError`: if the operation is creating duplicate
+            keys in two different documents. Only occurs if the keys have
+            unique indexes. See :meth:`AbstractDB.ensure_index` for more
+            information about indexes.
+
         """
         pass
 
@@ -168,6 +173,11 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
 
         :return: updated first matched document or None if nothing found
 
+        :raises :exc:`DuplicateKeyError`: if the operation is creating duplicate
+            keys in two different documents. Only occurs if the keys have
+            unique indexes. See :meth:`AbstractDB.ensure_index` for more
+            information about indexes.
+
         """
         pass
 
@@ -205,6 +215,14 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
 class DatabaseError(RuntimeError):
     """Exception type used to delegate responsibility from any database
     implementation's own Exception types.
+    """
+
+    pass
+
+
+class DuplicateKeyError(DatabaseError):
+    """Exception type used when a write attempt is made but the new document
+    have an index already contained in the database.
     """
 
     pass

--- a/src/metaopt/core/io/database/__init__.py
+++ b/src/metaopt/core/io/database/__init__.py
@@ -14,7 +14,6 @@ Currently, implemented wrappers:
 
 """
 from abc import abstractmethod, abstractproperty
-import logging
 
 from metaopt.core.utils import (AbstractSingletonType, SingletonFactory)
 
@@ -45,8 +44,6 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
     def __init__(self, host='localhost', name=None,
                  port=None, username=None, password=None):
         """Init method, see attributes of :class:`AbstractDB`."""
-        self._logger = logging.getLogger(__name__)
-
         self.host = host
         self.name = name
         self.port = port

--- a/src/metaopt/core/io/database/__init__.py
+++ b/src/metaopt/core/io/database/__init__.py
@@ -39,6 +39,9 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
 
     """
 
+    ASCENDING = 0
+    DESCENDING = 1
+
     def __init__(self, host='localhost', name=None,
                  port=None, username=None, password=None):
         """Init method, see attributes of :class:`AbstractDB`."""
@@ -74,8 +77,34 @@ class AbstractDB(object, metaclass=AbstractSingletonType):
         pass
 
     @abstractmethod
-    def write(self, collection_name, data,
-              query=None):
+    def ensure_index(self, collection_name, keys, unique=False):
+        """Create given indexes if they do not already exist in database.
+
+        Parameters
+        ----------
+        collection_name : str
+           A collection inside database, a table.
+        keys: str or list of tuples
+           Can be a string representing a key to index, or a list of tuples
+           with the structure `[(key_name, sort_order)]`. `key_name` must be a
+           string and sort_order can be either `AbstractDB.ASCENDING` or
+           AbstractDB.DESCENDING`.
+        unique: bool, optional
+           Ensure each document have a different key value. If not, operations
+           like `write()` and `read_and_write()` will raise
+           `DuplicateKeyError`.
+           Defaults to False.
+
+        .. note::
+            Depending on the backend, the indexing operation might operate in
+            background. This means some operations on the database might occur
+            before the indexes are totally built.
+
+        """
+        pass
+
+    @abstractmethod
+    def write(self, collection_name, data, query=None):
         """Write new information to a collection. Perform insert or update.
 
         Parameters

--- a/tests/unittests/core/experiment.yaml
+++ b/tests/unittests/core/experiment.yaml
@@ -51,7 +51,7 @@
       suspend: False
       done: False
 
-- name: supernaedo2
+- name: supernaedo3
 
   metadata:
     user: tsirif


### PR DESCRIPTION
Related to #10, #14 and #41 .
Needs #36 and #53 to be merged.

### Why:

Our main and only database back end is a NoSQL one and only `_id` is indexed by default. That means every `read` operation (including reads necessary in updates with queries) needs to parse the entire collection unless the query specifies the _id. This is highly inefficient. Adding indexes on keys which are often used in queries will significantly improve the database operations.

Additionally, we want to force some keys to be unique, namely the tuple (experiment name, user name). To do so we need a method to specify unique indexes.

- Experiments are believed to be mostly queried by (name, user) or status, so those keys are indexed.
- Trials are mostly queried by experiment, status, results, start_time or end_time.

### How:

#### Add `ensure_index` method to `AbstractDB`.

- Keys can be specified by name and optionally by sort order too.
- Keys can be forced to be unique.
- Generic sort orders are added to `AbstractDB`.
- `MongoDB` backend uses `dbcollection.create_index()`

#### Add generic `DuplicateKeyError` and a decorator for `MongoDB` methods.
- If the wrapped method raises `pymongo.errors.DuplicateKeyError`, it is converted to generic `DuplicateKeyError`.
- If the wrapped method raises `pymongo.errors.BulkWriteError`  containing at least one "duplicate key error", it is converted to  generic `DuplicateKeyError`.

Note: `pymongo.errors.BulkWriteError` can contain different type of errors. For conversion simplicity DuplicateKeyError` will have precedence over the others.

#### Add index configuration during experiment initialization. 

#### Add to `cli` handling of configuration failures due to race condition.

---

### Note:
Unittest configuration contained two experiments with the same tuple
(name, user). The addition of enforced uniqueness on this tuple makes
many unittest crash.